### PR TITLE
Fix zone1 range display

### DIFF
--- a/javaScript/modelo.js
+++ b/javaScript/modelo.js
@@ -2,6 +2,7 @@ function updateZones() {
     const heartRate = parseInt(document.getElementById('heartRateInput').value);
     
     // Cálculos baseados na porcentagem da média de batimentos cardíacos
+    const zone1Min = 0;
     const zone1Max = Math.round(heartRate * 0.82);
     const zone2Min = Math.round(heartRate * 0.83);
     const zone2Max = Math.round(heartRate * 0.89);
@@ -12,7 +13,7 @@ function updateZones() {
     const zone5Min = Math.round(heartRate * 1.06);
 
     // Atualizando os valores das zonas
-    document.getElementById('zone1').innerText = `Zona 1: até ${zone1Max} bpm`;
+    document.getElementById('zone1').innerText = `Zona 1: ${zone1Min} até ${zone1Max} bpm`;
     document.getElementById('zone2').innerText = `Zona 2: ${zone2Min} até ${zone2Max} bpm`;
     document.getElementById('zone3').innerText = `Zona 3: ${zone3Min} até ${zone3Max} bpm`;
     document.getElementById('zone4').innerText = `Zona 4: ${zone4Min} até ${zone4Max} bpm`;


### PR DESCRIPTION
## Summary
- show starting value for zone 1 in the heart rate zone calculator

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6852a02408cc83329418df6660a87c71